### PR TITLE
Fix truncate 2 mutable references 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc --verbose
+  - ./ci/miri.sh
 
 before_deploy:
   - cargo doc --verbose

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -ex
+
+export CARGO_NET_RETRY=5
+export CARGO_NET_TIMEOUT=10
+
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+cargo miri test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,3 +475,22 @@ impl<T> Display for CapacityError<T> {
         write!(f, "Insufficient capacity")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ArrayVec;
+
+    #[test]
+    fn test_equal_to_expected_slice() {
+        let mut vector: ArrayVec<u8, 10> = ArrayVec::new();
+        vector.push(0);
+        vector.push(1);
+        vector.push(2);
+        assert_eq!(vector.len(), 3);
+
+        vector.try_insert(3, 3).unwrap();
+
+        assert_eq!(vector.as_slice(), &[0, 1, 2, 3]);
+        assert_eq!(vector.capacity(), 10);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,12 +180,14 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
     pub fn truncate(&mut self, new_length: usize) {
         unsafe {
             if new_length < self.len() {
-                let start = self.as_mut_ptr().add(new_length);
                 let num_elements_to_remove = self.len() - new_length;
+                // Start by setting the new length, so we can "pre-poop our pants" (http://cglab.ca/~abeinges/blah/everyone-poops/)
+                self.set_len(new_length);
+
+                let start = self.as_mut_ptr().add(new_length);
                 let tail: *mut [T] =
                     slice::from_raw_parts_mut(start, num_elements_to_remove);
 
-                self.set_len(new_length);
                 ptr::drop_in_place(tail);
             }
         }


### PR DESCRIPTION
Hi,
The problem is basically that `self.set_len()` creates a unique mutable reference(`&mut self`) even though we already have a `*mut [T]` so, one can easily invalidate the other,
The solution here is to just inline `self.length = new_length` so that no unique mutable reference to `self` is created.
I discovered this using miri, and then when I asked @RalfJung he showed me that he fixed the same thing in https://github.com/bluss/arrayvec/pull/144
I copied the `miri.sh` file from his PR.

You can see the problem yourself by running: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=bb0b383aca6792aa7e1dc96a9979ffa3