### PR TITLE
Add more features and allow inlining

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         }
 
         unsafe {
-            self.insert_unchecked(index, item, len);
+            self.insert_unchecked(index, item);
         }
 
         Ok(())
@@ -333,7 +333,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
             // Since nothing's going to be removed, the vector's size
             // is going to be increased and nothing will be returned.
             unsafe {
-                self.insert_unchecked(index, item, len);
+                self.insert_unchecked(index, item);
             }
             result = None;
         }
@@ -342,20 +342,16 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
     }
 
     /// Insert an item into the vector without checking if the index is
-    /// valid or if the vector isn't full or the vector's length.
+    /// valid or if the vector isn't full.
     ///
     /// # Safety
     ///
     /// If you plan on using this function, you need to check for the
-    /// 3 previously mentioned conditions yourself before calling this
+    /// 2 previously mentioned conditions yourself before calling this
     /// method.
     #[inline]
-    pub unsafe fn insert_unchecked(
-        &mut self,
-        index: usize,
-        item: T,
-        len: usize,
-    ) {
+    pub unsafe fn insert_unchecked(&mut self, index: usize, item: T) {
+        let len = self.len();
         self.insert_unchecked_keep_len(index, item, len);
         self.set_len(len + 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,7 +460,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         // Read the value before sending it to the other world.
         let item = ptr::read(p);
         // Shift every value after the removed one to the left.
-        ptr::copy(p.add(1), p, len - index);
+        ptr::copy(p.add(1), p, len - index - 1);
         // We removed an item, so the length should be decremented.
         self.set_len(len - 1);
 
@@ -708,5 +708,23 @@ mod tests {
 
         assert_eq!(vector.as_slice(), &[0, 1, 2, 3]);
         assert_eq!(vector.capacity(), 10);
+    }
+
+    #[test]
+    fn test_force_insert_and_remove() {
+        let mut vector: ArrayVec<u8, 2> = ArrayVec::new();
+
+        // force_insert
+        vector.force_insert(0, 2);
+        vector.force_insert(1, 4);
+        vector.force_insert(0, 4);
+        assert_eq!(vector.as_slice(), &[4, 2]);
+
+        // remove
+        assert_eq!(vector.remove(0), 4);
+        assert_eq!(vector.as_slice(), &[2]);
+        assert_eq!(vector.try_remove(1), None);
+        assert_eq!(vector.remove(0), 2);
+        assert_eq!(vector.len(), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,20 +49,27 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         }
     }
 
+    #[inline]
     pub const fn len(&self) -> usize { self.length }
 
+    #[inline]
     pub const fn is_empty(&self) -> bool { self.len() == 0 }
 
+    #[inline]
     pub const fn capacity(&self) -> usize { N }
 
+    #[inline]
     pub const fn remaining_capacity(&self) -> usize {
         self.capacity() - self.len()
     }
 
+    #[inline]
     pub const fn is_full(&self) -> bool { self.len() >= self.capacity() }
 
+    #[inline]
     pub fn as_ptr(&self) -> *const T { self.items.as_ptr() as *const T }
 
+    #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T { self.items.as_mut_ptr() as *mut T }
 
     /// Add an item to the end of the vector.
@@ -140,6 +147,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
     /// This method is `unsafe` because it changes the number of "valid"
     /// elements the vector thinks it contains, without adding or removing any
     /// elements. Use with care.
+    #[inline]
     pub unsafe fn set_len(&mut self, new_length: usize) {
         debug_assert!(new_length <= self.capacity());
         self.length = new_length;
@@ -194,6 +202,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
     }
 
     /// Remove all items from the vector.
+    #[inline]
     pub fn clear(&mut self) { self.truncate(0); }
 
     /// Insert an item.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub struct ArrayVec<T, const N: usize> {
 
 impl<T, const N: usize> ArrayVec<T, { N }> {
     /// Create a new, empty [`ArrayVec`].
+    #[inline]
     pub fn new() -> ArrayVec<T, { N }> {
         unsafe {
             ArrayVec {
@@ -436,6 +437,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
     /// assert_eq!(what, None);
     /// assert_eq!(&vector, [4, 2].as_ref());
     /// ```
+    #[inline]
     pub fn try_remove(&mut self, index: usize) -> Option<T> {
         if index < self.len() {
             Some(unsafe { self.remove_unchecked(index) })
@@ -465,8 +467,10 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         item
     }
 
+    #[inline]
     pub fn as_slice(&self) -> &[T] { self.deref() }
 
+    #[inline]
     pub fn as_slice_mut(&mut self) -> &mut [T] { self.deref_mut() }
 
     pub fn try_extend_from_slice(
@@ -493,6 +497,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         Ok(())
     }
 
+    #[inline]
     pub fn drain(&mut self, range: Range<usize>) -> Drain<'_, T, { N }> {
         Drain::with_range(self, range)
     }
@@ -501,12 +506,14 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
 impl<T, const N: usize> Deref for ArrayVec<T, { N }> {
     type Target = [T];
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { slice::from_raw_parts(self.as_ptr(), self.len()) }
     }
 }
 
 impl<T, const N: usize> DerefMut for ArrayVec<T, { N }> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len()) }
     }
@@ -550,6 +557,7 @@ impl<T, const N: usize> Drop for ArrayVec<T, { N }> {
     /// // and the counter should have updated
     /// assert_eq!(counter.load(Ordering::Relaxed), 3);
     /// ```
+    #[inline]
     fn drop(&mut self) {
         // Makes sure the destructors for all items are run.
         self.clear();
@@ -557,14 +565,17 @@ impl<T, const N: usize> Drop for ArrayVec<T, { N }> {
 }
 
 impl<T, const N: usize> AsRef<[T]> for ArrayVec<T, { N }> {
+    #[inline]
     fn as_ref(&self) -> &[T] { self.as_slice() }
 }
 
 impl<T, const N: usize> AsMut<[T]> for ArrayVec<T, { N }> {
+    #[inline]
     fn as_mut(&mut self) -> &mut [T] { self.as_slice_mut() }
 }
 
 impl<T: Debug, const N: usize> Debug for ArrayVec<T, { N }> {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.as_slice().fmt(f)
     }
@@ -573,34 +584,40 @@ impl<T: Debug, const N: usize> Debug for ArrayVec<T, { N }> {
 impl<T: PartialEq, const N: usize, const M: usize> PartialEq<ArrayVec<T, { M }>>
     for ArrayVec<T, { N }>
 {
+    #[inline]
     fn eq(&self, other: &ArrayVec<T, { M }>) -> bool {
         self.as_slice() == other.as_slice()
     }
 }
 
 impl<T: PartialEq, const N: usize> PartialEq<[T]> for ArrayVec<T, { N }> {
+    #[inline]
     fn eq(&self, other: &[T]) -> bool { self.as_slice() == other }
 }
 
 impl<T: Eq, const N: usize> Eq for ArrayVec<T, { N }> {}
 
 impl<T: PartialOrd, const N: usize> PartialOrd for ArrayVec<T, { N }> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.as_slice().partial_cmp(other.as_slice())
     }
 }
 
 impl<T: Ord, const N: usize> Ord for ArrayVec<T, { N }> {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_slice().cmp(other.as_slice())
     }
 }
 
 impl<T: Hash, const N: usize> Hash for ArrayVec<T, { N }> {
+    #[inline]
     fn hash<H: Hasher>(&self, hasher: &mut H) { self.as_slice().hash(hasher); }
 }
 
 impl<T, const N: usize> Default for ArrayVec<T, { N }> {
+    #[inline]
     fn default() -> Self { ArrayVec::new() }
 }
 
@@ -610,6 +627,7 @@ where
 {
     type Output = <[T] as Index<Ix>>::Output;
 
+    #[inline]
     fn index(&self, ix: Ix) -> &Self::Output { self.as_slice().index(ix) }
 }
 
@@ -617,6 +635,7 @@ impl<Ix, T, const N: usize> IndexMut<Ix> for ArrayVec<T, { N }>
 where
     [T]: IndexMut<Ix>,
 {
+    #[inline]
     fn index_mut(&mut self, ix: Ix) -> &mut Self::Output {
         self.as_slice_mut().index_mut(ix)
     }
@@ -667,6 +686,7 @@ impl<T, const N: usize> From<[T; N]> for ArrayVec<T, { N }> {
 pub struct CapacityError<T>(pub T);
 
 impl<T> Display for CapacityError<T> {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Insufficient capacity")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
     ///
     /// # Panics
     ///
-    /// The index isn't valid (i.e. is out of bounds).
+    /// The index is out of bounds.
     ///
     /// # Examples
     ///
@@ -421,8 +421,8 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         }
     }
 
-    /// If `index` is valid, remove the value contained at `index` and
-    /// return it.
+    /// If `index` is in bounds, remove the value contained at `index`
+    /// and return it.
     ///
     /// # Examples
     ///
@@ -446,12 +446,11 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         }
     }
 
-    /// Remove the value contained at the passed index and
-    /// return it.
+    /// Remove the value contained at `index` and return it.
     ///
     /// # Safety
     ///
-    /// The index must be valid (i.e. `index < vec.len()`).
+    /// The index must be in bounds.
     pub unsafe fn remove_unchecked(&mut self, index: usize) -> T {
         let len = self.len();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         let len = self.len();
 
         // bounds checks
-        if index > self.len() {
+        if index > len {
             out_of_bounds!("try_insert", index, len);
         }
         if self.is_full() {
@@ -299,7 +299,7 @@ impl<T, const N: usize> ArrayVec<T, { N }> {
         let other_len = other.len();
 
         unsafe {
-            let dst = self.as_mut_ptr().offset(self_len as isize);
+            let dst = self.as_mut_ptr().add(self_len);
             // Note: we have a mutable reference to self, so it's not possible
             // for the two arrays to overlap
             ptr::copy_nonoverlapping(other.as_ptr(), dst, other_len);


### PR DESCRIPTION
Hey,

This PR adds some of the features that this crate was missing from the original `arrayvec`:

- `remove`
- `try_remove` (`pop_at` in `arrayvec`)
- `swap_remove`
- `try_swap_remove` (`swap_pop` in `arrayvec`)

Along with some other features:

- `force_insert` (if already full, remove and return the last item)
- `insert_unchecked`
- `insert_unchecked_keep_len` (doesn't increment the length)
- `remove_unchecked`
- `swap_remove_unchecked`

There is a full documentation for those functions and every non-`unchecked` function have examples to go with them. Also, a test called `test_force_insert_and_remove` has been added since it looked like Miri doesn't want to run doc tests.

Another thing this PR adds is `#[inline]` to small funtions: `rustc` *never* inlines anything in libraries, except when performing LTO which is not enabled by default (see https://doc.rust-lang.org/cargo/reference/manifest.html for default cargo configurations). Adding `#[inline]` therefor allows `rustc` to inline and optimize some functions *if it feels like it* in exchange for a longer compile-time and, probably, a larger binary.

Anyway, sorry for making a PR this big, each time I touched something there was always "that one little thing" I wanted to add, so: thank you for reading this! Please tell me if there's anything that isn't clear or that should be changed.